### PR TITLE
Fix typos and add helper tests

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -29,7 +29,7 @@ function setDefaultScheduleSettings() {
     let schedule = {
         autoExtract: 0
     };
-    //Cmp setttings
+    //Cmp settings
     return schedule;
 }
 
@@ -38,7 +38,7 @@ function setDefaultGeneralSettings() {
     let general = {
         defaultDashboard: 'general'
     };
-    //Cmp setttings
+    //Cmp settings
     return general;
 }
 
@@ -55,7 +55,7 @@ function setDefaultInvPricingSettings() {
             numberOfDates: "5"
         }
     };
-    //Cmp setttings
+    //Cmp settings
     let steps = [
         {
             min: 0,

--- a/extension/content_dashboard.js
+++ b/extension/content_dashboard.js
@@ -2190,7 +2190,7 @@ function displayAircraftProfitability() {
                 nickname: value.nickname,
                 note: value.note,
                 age: value.age,
-                maintenance: value.maintanence,
+                maintenance: value.maintenance,
                 dateAircraft: AES.formatDateString(value.date) + ' ' + value.time,
                 totalFlights: profit.totalFlights,
                 finishedFlights: profit.finishedFlights,

--- a/extension/content_fleetManagement.js
+++ b/extension/content_fleetManagement.js
@@ -35,7 +35,7 @@ function fltmng_getData() {
             nickname: fltmng_getNickname($('td:eq(1) > div:eq(0)', this).text()),
             equipment: $('td:eq(2) > a:eq(0)', this).text(),
             age: fltmng_getAge($('td:eq(4) > span:eq(0)', this).text()),
-            maintenance: fltmng_getMaintanance($('td:eq(4) > div > span:eq(1)', this).text()),
+            maintenance: fltmng_getMaintenance($('td:eq(4) > div > span:eq(1)', this).text()),
             aircraftId: fltmng_getAircraftId($('td:eq(6) > div > div:eq(1) > a:eq(0)', this).attr('href')),
             note: fltmng_getNickname($('td:eq(7) > span > span', this).text()),
             fleet: fleet,
@@ -65,7 +65,7 @@ function fltmng_getAge(value) {
     }
 }
 
-function fltmng_getMaintanance(value) {
+function fltmng_getMaintenance(value) {
     value = value.replace('%', '');
     value = value.replace(',', '.');
     value = parseFloat(value);
@@ -130,7 +130,7 @@ function fltmng_updateAircraftFleetStorageData(data) {
                 date: newvalue.date,
                 equipment: newvalue.equipment,
                 fleet: newvalue.fleet,
-                maintanence: newvalue.maintanence,
+                maintenance: newvalue.maintenance,
                 nickname: newvalue.nickname,
                 note: newvalue.note,
                 registration: newvalue.registration,

--- a/extension/content_flightSchedule.js
+++ b/extension/content_flightSchedule.js
@@ -151,7 +151,7 @@ function extractSchedule() {
         //Flight number
         let flightNumber = $(".code:eq(0)", row).text().split(' ');
         flightNumber = parseInt(flightNumber[1], 10);
-        //Check if exist alraedy
+        //Check if flight number exists already
         if (!route.flightNumber) {
             route.flightNumber = {};
         }

--- a/extension/content_inventory.js
+++ b/extension/content_inventory.js
@@ -69,7 +69,7 @@ async function displayInventory() {
                 //Do nothing
             } else {
                 //Pricing not updated today
-                //Check if new price avaialble
+                //Check if new price available
                 if (analysis.hasValue('newPrice')) {
                     //Update price
                     if (settings.invPricing.autoPriceUpdate) {
@@ -79,7 +79,7 @@ async function displayInventory() {
             }
         } else {
             //Today update does not exists
-            //Check if new price avaialble
+            //Check if new price available
             if (analysis.hasValue('newPrice')) {
                 //Update price
                 if (settings.invPricing.autoPriceUpdate) {
@@ -411,7 +411,7 @@ function getAnalysis(flights, prices, storedData) {
         });
         //if no cmp flights
         if (cmpFlights.length) {
-            //Check if current price flights avaialble
+            //Check if current price flights available
             let flightsArray = cmpFlights.filter(function(flight) {
                 return (flight.price == price);
             });

--- a/extension/helpers.js
+++ b/extension/helpers.js
@@ -261,3 +261,5 @@ class AES {
 
 
 }
+
+module.exports = AES;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "airlinesim-enhancement-suite",
+  "version": "0.0.1",
+  "scripts": {
+    "test": "node test/helpers.test.js"
+  }
+}

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const AES = require('../extension/helpers.js');
+
+// Test AES.cleanInteger
+assert.strictEqual(AES.cleanInteger('2,000 AS$'), 2000);
+assert.strictEqual(AES.cleanInteger('-3.500 AS$'), -3500);
+assert.strictEqual(AES.cleanInteger('256'), 256);
+assert.strictEqual(AES.cleanInteger('invalid'), 0);
+
+// Test AES.formatDateString
+assert.strictEqual(AES.formatDateString('20240524'), '2024-05-24');
+assert.strictEqual(AES.formatDateString('bad'), 'error: invalid format for AES.formatDateString');
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- fix spelling in schedule script
- rename maintenance helper and property
- clean up typo comments
- export `AES` for Node tests
- add a basic test for helper utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404313a6908325b4cc35cb58ec13b7