### PR TITLE
Add import/export functionality to extension's options page

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -36,13 +36,13 @@
                 "modules/notification.js",
                 "modules/notifications.js"
             ],
-            "matches": ["https://*.airlinesim.aero/app/*", "https://*.airlinesim.aero/action/*"]
+            "matches": [
+                "https://*.airlinesim.aero/app/*",
+                "https://*.airlinesim.aero/action/*"
+            ]
         },
         {
-            "js": [
-                "content_inventory.js",
-                "modules/inventory/validation.js"
-            ],
+            "js": ["content_inventory.js", "modules/inventory/validation.js"],
             "matches": ["https://*.airlinesim.aero/app/com/inventory/*"]
         },
         {
@@ -59,7 +59,9 @@
         },
         {
             "js": ["content_personnelManagement.js"],
-            "matches": ["https://*.airlinesim.aero/action/enterprise/staffOverview*"]
+            "matches": [
+                "https://*.airlinesim.aero/action/enterprise/staffOverview*"
+            ]
         },
         {
             "js": ["content_enterpriseOverview.js"],
@@ -78,10 +80,18 @@
             "matches": ["https://*.airlinesim.aero/app/fleets*"]
         }
     ],
-    "permissions": ["activeTab", "declarativeContent", "storage", "unlimitedStorage"],
+    "permissions": [
+        "activeTab",
+        "declarativeContent",
+        "storage",
+        "unlimitedStorage"
+    ],
     "host_permissions": ["https://*.airlinesim.aero/"],
-    "web_accessible_resources": [{
-        "resources": ["/images/*"],
-        "matches": ["https://*.airlinesim.aero/*"]
-    }]
+    "options_page": "options.html",
+    "web_accessible_resources": [
+        {
+            "resources": ["/images/*"],
+            "matches": ["https://*.airlinesim.aero/*"]
+        }
+    ]
 }

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,23 +1,189 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-    <script src="js/jquery-3.4.1.min.js"></script>
-    <title>AirlineSim Enhancement Suite Data Manager</title>
-  </head>
-  <body>
+    <head>
+        <link
+            rel="stylesheet"
+            href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
+            integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh"
+            crossorigin="anonymous"
+        />
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"
+        />
+        <script src="js/vendor/jquery-3.7.1.slim.min.js"></script>
+        <title>AirlineSim Enhancement Suite Import/Export</title>
+        <style>
+            .backup-restore-section {
+                background-color: #f8f9fa;
+                border: 1px solid #dee2e6;
+                border-radius: 0.375rem;
+                padding: 1.5rem;
+                margin-bottom: 2rem;
+            }
+            .data-stats {
+                background-color: #e9ecef;
+                border-radius: 0.375rem;
+                padding: 1rem;
+                margin-bottom: 1rem;
+            }
+            .file-input-wrapper {
+                position: relative;
+                overflow: hidden;
+                display: inline-block;
+            }
+            .file-input-wrapper input[type="file"] {
+                position: absolute;
+                left: -9999px;
+            }
+            .status-message {
+                margin-top: 1rem;
+                padding: 0.75rem;
+                border-radius: 0.375rem;
+                display: none;
+            }
+            .status-success {
+                background-color: #d4edda;
+                border: 1px solid #c3e6cb;
+                color: #155724;
+            }
+            .status-error {
+                background-color: #f8d7da;
+                border: 1px solid #f5c6cb;
+                color: #721c24;
+            }
+            .status-warning {
+                background-color: #fff3cd;
+                border: 1px solid #ffeaa7;
+                color: #856404;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container pt-3" id="display">
+            <h1>
+                <i class="fas fa-file-import"></i> AirlineSim Enhancement Suite
+                Import/Export
+            </h1>
 
-    <div class="container pt-3" id="display">
-      <h1>AirlineSim Enhancement Suite Data Manager</h1>
-      <p>Page under development...</p>
-      <div class="form-inline" id="aes-div-topSelect">
-      </div>
-      <div id="aes-div-dataDisplay">
-      </div>
+            <!-- Backup and Restore Section -->
+            <div class="backup-restore-section">
+                <h2><i class="fas fa-shield-alt"></i> Backup & Restore</h2>
+                <p class="text-muted">
+                    Backup your AES data to a file or restore from a previous
+                    backup.
+                </p>
 
+                <div class="row">
+                    <div class="col-md-6">
+                        <h4><i class="fas fa-download"></i> Backup Data</h4>
+                        <div class="data-stats" id="aes-data-stats">
+                            <h6>Current Data Summary:</h6>
+                            <div id="aes-stats-content">Loading...</div>
+                        </div>
+                        <div class="form-group">
+                            <label for="aes-backup-type">Backup Type:</label>
+                            <select class="form-control" id="aes-backup-type">
+                                <option value="all">All Data</option>
+                                <option value="settings">Settings Only</option>
+                                <option value="schedule">Schedule Data</option>
+                                <option value="pricing">Pricing Data</option>
+                                <option value="competitorMonitoring">
+                                    Competitor Monitoring
+                                </option>
+                                <option value="flightInfo">Flight Info</option>
+                                <option value="aircraftData">
+                                    Aircraft Data
+                                </option>
+                            </select>
+                        </div>
+                        <button class="btn btn-primary" id="aes-backup-btn">
+                            <i class="fas fa-download"></i> Create Backup
+                        </button>
+                    </div>
 
+                    <div class="col-md-6">
+                        <h4><i class="fas fa-upload"></i> Restore Data</h4>
+                        <div class="form-group">
+                            <label for="aes-restore-file"
+                                >Select Backup File:</label
+                            >
+                            <div class="file-input-wrapper">
+                                <input
+                                    type="file"
+                                    id="aes-restore-file"
+                                    accept=".json"
+                                    class="form-control-file"
+                                    style="display: none"
+                                />
+                                <button
+                                    type="button"
+                                    class="btn btn-outline-secondary"
+                                    id="aes-choose-file-btn"
+                                >
+                                    <i class="fas fa-file-upload"></i> Choose
+                                    File
+                                </button>
+                                <span
+                                    id="aes-selected-file-name"
+                                    class="ml-2 text-muted"
+                                ></span>
+                            </div>
+                            <small class="form-text text-muted"
+                                >Select a JSON backup file created by AES</small
+                            >
+                        </div>
+                        <div class="form-group">
+                            <label for="aes-restore-mode">Restore Mode:</label>
+                            <select class="form-control" id="aes-restore-mode">
+                                <option value="merge">
+                                    Merge with existing data
+                                </option>
+                                <option value="replace">
+                                    Replace existing data
+                                </option>
+                            </select>
+                        </div>
+                        <button
+                            class="btn btn-success"
+                            id="aes-restore-btn"
+                            disabled
+                        >
+                            <i class="fas fa-upload"></i> Restore Data
+                        </button>
+                    </div>
+                </div>
 
-    </div>
-  </body>
-  <script src="options.js"></script>
+                <div class="status-message" id="aes-status-message"></div>
+            </div>
+
+            <!-- Data Cleanup Section -->
+            <div class="backup-restore-section">
+                <h2><i class="fas fa-trash-alt"></i> Data Cleanup</h2>
+                <p class="text-muted">Remove data to free up storage space.</p>
+
+                <div class="row">
+                    <div class="col-md-6">
+                        <button
+                            class="btn btn-warning btn-block mb-2"
+                            id="aes-clear-old-data-btn"
+                        >
+                            <i class="fas fa-calendar-times"></i> Clear Old Data
+                            (>30 days)
+                        </button>
+                    </div>
+                    <div class="col-md-6">
+                        <button
+                            class="btn btn-danger btn-block"
+                            id="aes-clear-all-data-btn"
+                        >
+                            <i class="fas fa-exclamation-triangle"></i> Clear
+                            All Data
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+    <script src="options.js"></script>
 </html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,160 +1,448 @@
 "use strict";
 //Main
-var dataPoints = {};
-var servers = [];
-var airlines = [];
-var types = [];
-var data;
-$(function() {
+var allStorageData = {};
+
+$(function () {
     //Get saved data
-    chrome.storage.local.get(null, function(items) {
-        data = items;
-        for (let key in items) {
-            //Get all servers,airlines,types
-            if (items[key].server) {
-                let server = items[key].server;
-                let airline = items[key].airline;
-                let type = items[key].type;
+    chrome.storage.local.get(null, function (items) {
+        allStorageData = items;
 
-                if (!servers.includes(server)) {
-                    servers.push(server);
-                }
-                if (!airlines.includes(airline)) {
-                    airlines.push(airline);
-                }
-                if (!types.includes(type)) {
-                    types.push(type);
-                }
+        // Initialize backup and restore functionality
+        initializeBackupRestore();
 
-                //get server
-                if (!dataPoints[server]) {
-                    dataPoints[server] = {};
-                }
-                //Get airline
-                if (!dataPoints[server][airline]) {
-                    dataPoints[server][airline] = {};
-                }
-                //Get type
-                if (!dataPoints[server][airline][type]) {
-                    //Depending on type if drill deeper
-                    //Pricing
-                    if (items[key].type == 'pricing') {
-                        dataPoints[server][airline][type] = {};
-                    }
-                    //schedule
-                    if (items[key].type == 'schedule') {
-                        dataPoints[server][airline][type] = [];
-                    }
-                }
-                //get pricing
-                if (items[key].type == 'pricing') {
-                    let od = items[key].origin + items[key].destination;
-                    //check if exists
-                    if (!dataPoints[server][airline][type][od]) {
-                        dataPoints[server][airline][type][od] = [];
-                    }
-                    for (let date in items[key].date) {
-                        dataPoints[server][airline][type][od].push(date);
-                    }
-                }
-                //get schedule
-                if (items[key].type == 'schedule') {
-                    for (let date in items[key].data) {
-                        dataPoints[server][airline][type].push(date);
-                    }
-                }
-            }
-        }
-        //Check if any data
-        if (Object.keys(dataPoints).length) {
-            //Object not empty
-
-            displayTopSelector();
-        } else {
-            //Object empty
-            $('#display').append('There is no data')
-        }
+        // Display data statistics
+        displayDataStatistics();
     });
 });
 //Functions
-function displayTopSelector() {
-    $('#aes-div-topSelect').append(createTopSelect(servers, 'server'));
-    $('#aes-div-topSelect').append(createTopSelect(airlines, 'airline'));
-    $('#aes-div-topSelect').append(createTopSelect(types, 'type'));
-    topSelectHandle();
-    $('#aes-select-top-server').change(function() {
-        topSelectHandle();
+
+// Backup and Restore Functions
+function initializeBackupRestore() {
+    // Backup button click handler
+    $("#aes-backup-btn").click(function () {
+        createBackup();
     });
-    $('#aes-select-top-airline').change(function() {
-        topSelectHandle();
+
+    // Choose file button click handler
+    $("#aes-choose-file-btn").click(function () {
+        $("#aes-restore-file").click();
     });
-    $('#aes-select-top-type').change(function() {
-        topSelectHandle();
+
+    // Restore file input change handler
+    $("#aes-restore-file").change(function (event) {
+        const file = event.target.files[0];
+        if (file) {
+            $("#aes-restore-btn").prop("disabled", false);
+            $("#aes-selected-file-name").text(file.name);
+            showStatusMessage("File selected: " + file.name, "info");
+        } else {
+            $("#aes-restore-btn").prop("disabled", true);
+            $("#aes-selected-file-name").text("");
+        }
+    });
+
+    // Restore button click handler
+    $("#aes-restore-btn").click(function () {
+        restoreData();
+    });
+
+    // Clear old data button
+    $("#aes-clear-old-data-btn").click(function () {
+        if (
+            confirm(
+                "Are you sure you want to clear data older than 30 days? This action cannot be undone."
+            )
+        ) {
+            clearOldData();
+        }
+    });
+
+    // Clear all data button
+    $("#aes-clear-all-data-btn").click(function () {
+        if (
+            confirm(
+                "Are you sure you want to clear ALL data? This action cannot be undone.\n\nConsider creating a backup first."
+            )
+        ) {
+            if (
+                confirm(
+                    "This will permanently delete all your AES data. Are you absolutely sure?"
+                )
+            ) {
+                clearAllData();
+            }
+        }
     });
 }
 
-function createTopSelect(array, name) {
-    let label = $('<label for="aes-select-top-' + name + '" class="mr-sm-2"></label>').text(name + ":");
-    let select = $('<select id="aes-select-top-' + name + '" class="form-control mb-2 mr-sm-2"></select>');
-    for (let i in array) {
-        select.append($('<option></option>').attr("value", array[i]).text(array[i]));
+function displayDataStatistics() {
+    const stats = analyzeStorageData(allStorageData);
+
+    if (stats.totalItems === 0) {
+        $("#aes-stats-content").html(
+            '<p class="text-muted">No data found. Start using AES to see statistics here.</p>'
+        );
+        return;
     }
-    $('#aes-div-topSelect').append(label, select)
+
+    const statsHtml = `
+        <div class="row">
+            <div class="col-md-3">
+                <strong>Total Items:</strong><br>
+                <span class="badge badge-primary">${stats.totalItems}</span>
+            </div>
+            <div class="col-md-3">
+                <strong>Settings:</strong><br>
+                <span class="badge badge-info">${stats.settings}</span>
+            </div>
+            <div class="col-md-3">
+                <strong>Schedule Data:</strong><br>
+                <span class="badge badge-success">${stats.schedule}</span>
+            </div>
+            <div class="col-md-3">
+                <strong>Other Data:</strong><br>
+                <span class="badge badge-secondary">${stats.other}</span>
+            </div>
+        </div>
+        <div class="row mt-2">
+            <div class="col-md-4">
+                <strong>Pricing Data:</strong><br>
+                <span class="badge badge-warning">${stats.pricing}</span>
+            </div>
+            <div class="col-md-4">
+                <strong>Flight Info:</strong><br>
+                <span class="badge badge-info">${stats.flightInfo}</span>
+            </div>
+            <div class="col-md-4">
+                <strong>Estimated Size:</strong><br>
+                <span class="badge badge-dark">${formatBytes(
+                    stats.estimatedSize
+                )}</span>
+            </div>
+        </div>
+    `;
+    $("#aes-stats-content").html(statsHtml);
 }
 
-function topSelectHandle() {
-    let server = $('#aes-select-top-server').val();
-    let airline = $('#aes-select-top-airline').val();
-    let type = $('#aes-select-top-type').val();
-    let div = $('#aes-div-dataDisplay');
-    div.empty();
+function analyzeStorageData(data) {
+    const stats = {
+        totalItems: 0,
+        settings: 0,
+        schedule: 0,
+        pricing: 0,
+        flightInfo: 0,
+        competitorMonitoring: 0,
+        aircraftData: 0,
+        other: 0,
+        estimatedSize: 0,
+    };
+
+    for (let key in data) {
+        stats.totalItems++;
+        const item = data[key];
+        const jsonSize = JSON.stringify(item).length;
+        stats.estimatedSize += jsonSize;
+
+        if (key === "settings") {
+            stats.settings++;
+        } else if (item && item.type) {
+            switch (item.type) {
+                case "schedule":
+                    stats.schedule++;
+                    break;
+                case "pricing":
+                    stats.pricing++;
+                    break;
+                case "competitorMonitoring":
+                    stats.competitorMonitoring++;
+                    break;
+                default:
+                    stats.other++;
+            }
+        } else if (key.includes("flightInfo")) {
+            stats.flightInfo++;
+        } else if (
+            key.includes("aircraftProfitability") ||
+            key.includes("aircraft")
+        ) {
+            stats.aircraftData++;
+        } else {
+            stats.other++;
+        }
+    }
+
+    return stats;
+}
+
+function createBackup() {
+    const backupType = $("#aes-backup-type").val();
+    showStatusMessage("Creating backup...", "info");
+
+    chrome.storage.local.get(null, function (items) {
+        let backupData = {};
+
+        if (backupType === "all") {
+            backupData = items;
+        } else {
+            // Filter data based on backup type
+            for (let key in items) {
+                const item = items[key];
+
+                switch (backupType) {
+                    case "settings":
+                        if (key === "settings") {
+                            backupData[key] = item;
+                        }
+                        break;
+                    case "schedule":
+                        if (item && item.type === "schedule") {
+                            backupData[key] = item;
+                        }
+                        break;
+                    case "pricing":
+                        if (item && item.type === "pricing") {
+                            backupData[key] = item;
+                        }
+                        break;
+                    case "competitorMonitoring":
+                        if (item && item.type === "competitorMonitoring") {
+                            backupData[key] = item;
+                        }
+                        break;
+                    case "flightInfo":
+                        if (key.includes("flightInfo")) {
+                            backupData[key] = item;
+                        }
+                        break;
+                    case "aircraftData":
+                        if (
+                            key.includes("aircraftProfitability") ||
+                            key.includes("aircraft")
+                        ) {
+                            backupData[key] = item;
+                        }
+                        break;
+                }
+            }
+        }
+
+        // Create backup object with metadata
+        const backup = {
+            metadata: {
+                version: "0.7.0",
+                created: new Date().toISOString(),
+                type: backupType,
+                itemCount: Object.keys(backupData).length,
+            },
+            data: backupData,
+        };
+
+        // Download backup file
+        downloadBackup(backup, backupType);
+        showStatusMessage(
+            `Backup created successfully! ${backup.metadata.itemCount} items exported.`,
+            "success"
+        );
+    });
+}
+
+function downloadBackup(backup, type) {
+    const filename = `aes-backup-${type}-${
+        new Date().toISOString().split("T")[0]
+    }.json`;
+    const dataStr = JSON.stringify(backup, null, 2);
+    const dataBlob = new Blob([dataStr], { type: "application/json" });
+
+    const link = document.createElement("a");
+    link.href = URL.createObjectURL(dataBlob);
+    link.download = filename;
+    link.click();
+
+    // Clean up
+    URL.revokeObjectURL(link.href);
+}
+
+function restoreData() {
+    const file = $("#aes-restore-file")[0].files[0];
+    const restoreMode = $("#aes-restore-mode").val();
+
+    if (!file) {
+        showStatusMessage("Please select a backup file first.", "error");
+        return;
+    }
+
+    showStatusMessage("Reading backup file...", "info");
+
+    const reader = new FileReader();
+    reader.onload = function (e) {
+        try {
+            const backup = JSON.parse(e.target.result);
+
+            // Validate backup format
+            if (!backup.metadata || !backup.data) {
+                throw new Error("Invalid backup file format");
+            }
+
+            showStatusMessage(
+                `Restoring ${backup.metadata.itemCount} items...`,
+                "info"
+            );
+
+            if (restoreMode === "replace") {
+                // Clear existing data first
+                chrome.storage.local.clear(function () {
+                    chrome.storage.local.set(backup.data, function () {
+                        if (chrome.runtime.lastError) {
+                            showStatusMessage(
+                                "Error restoring data: " +
+                                    chrome.runtime.lastError.message,
+                                "error"
+                            );
+                        } else {
+                            showStatusMessage(
+                                "Data restored successfully! Please refresh the page.",
+                                "success"
+                            );
+                            setTimeout(() => location.reload(), 2000);
+                        }
+                    });
+                });
+            } else {
+                // Merge mode
+                chrome.storage.local.set(backup.data, function () {
+                    if (chrome.runtime.lastError) {
+                        showStatusMessage(
+                            "Error restoring data: " +
+                                chrome.runtime.lastError.message,
+                            "error"
+                        );
+                    } else {
+                        showStatusMessage(
+                            "Data merged successfully! Please refresh the page.",
+                            "success"
+                        );
+                        setTimeout(() => location.reload(), 2000);
+                    }
+                });
+            }
+        } catch (error) {
+            showStatusMessage(
+                "Error reading backup file: " + error.message,
+                "error"
+            );
+        }
+    };
+
+    reader.readAsText(file);
+}
+
+function clearOldData() {
+    showStatusMessage("Clearing old data...", "info");
+
+    chrome.storage.local.get(null, function (items) {
+        const thirtyDaysAgo = new Date();
+        thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+        const cutoffDate = thirtyDaysAgo.getTime();
+
+        const keysToRemove = [];
+
+        for (let key in items) {
+            const item = items[key];
+
+            // Skip settings
+            if (key === "settings") continue;
+
+            // Check if item has date information
+            if (item && item.date) {
+                // For items with date objects (like schedule data)
+                let hasRecentData = false;
+                for (let dateKey in item.date) {
+                    const itemDate = new Date(parseInt(dateKey));
+                    if (itemDate.getTime() > cutoffDate) {
+                        hasRecentData = true;
+                        break;
+                    }
+                }
+                if (!hasRecentData) {
+                    keysToRemove.push(key);
+                }
+            } else if (item && item.updateTime) {
+                // For items with updateTime
+                const itemDate = new Date(item.updateTime);
+                if (itemDate.getTime() < cutoffDate) {
+                    keysToRemove.push(key);
+                }
+            }
+        }
+
+        if (keysToRemove.length > 0) {
+            chrome.storage.local.remove(keysToRemove, function () {
+                showStatusMessage(
+                    `Cleared ${keysToRemove.length} old data items.`,
+                    "success"
+                );
+                setTimeout(() => location.reload(), 1500);
+            });
+        } else {
+            showStatusMessage("No old data found to clear.", "info");
+        }
+    });
+}
+
+function clearAllData() {
+    showStatusMessage("Clearing all data...", "warning");
+
+    chrome.storage.local.clear(function () {
+        if (chrome.runtime.lastError) {
+            showStatusMessage(
+                "Error clearing data: " + chrome.runtime.lastError.message,
+                "error"
+            );
+        } else {
+            showStatusMessage("All data cleared successfully!", "success");
+            setTimeout(() => location.reload(), 1500);
+        }
+    });
+}
+
+function showStatusMessage(message, type) {
+    const statusDiv = $("#aes-status-message");
+    statusDiv.removeClass(
+        "status-success status-error status-warning status-info"
+    );
+
     switch (type) {
-        case 'pricing':
-            displayPricingData(server, airline, type, div)
+        case "success":
+            statusDiv.addClass("status-success");
             break;
-        case 'schedule':
-            displayScheduleData(server, airline, type, div)
+        case "error":
+            statusDiv.addClass("status-error");
             break;
+        case "warning":
+            statusDiv.addClass("status-warning");
+            break;
+        case "info":
         default:
-            // code block
+            statusDiv.addClass("status-warning"); // Using warning style for info
+            break;
+    }
+
+    statusDiv.text(message).show();
+
+    // Auto-hide after 5 seconds for success/info messages
+    if (type === "success" || type === "info") {
+        setTimeout(() => {
+            statusDiv.fadeOut();
+        }, 5000);
     }
 }
 
-function displayPricingData(server, airline, type, div) {
-    //Table body
-    let tbody = $('<tbody></tbody>');
-    for (let od in dataPoints[server][airline][type]) {
-        let td1 = $('<td></td>').text(od);
-        let td2 = $('<td></td>').text(dataPoints[server][airline][type][od].length);
-        let row = $('<tr></tr>').append(td1, td2);
-        tbody.append(row);
-    }
-    //Table head
-    let th1 = $('<th></th>').text('OD');
-    let th2 = $('<th></th>').text('# of Data Points');
-    let headRow = $('<tr></tr>').append(th1, th2);
-    let thead = $('<thead></thead>').append(headRow);
-    //Table
-    let table = $('<table class="table table-hover"></table>').append(thead, tbody);
-    div.append(table);
-}
+function formatBytes(bytes) {
+    if (bytes === 0) return "0 Bytes";
 
-function displayScheduleData(server, airline, type, div) {
-    //Table body
-    let tbody = $('<tbody></tbody>');
-    dataPoints[server][airline][type].forEach(function(date) {
-        let td1 = $('<td></td>').text(date);
-        let td2 = $('<td></td>').text(data[type + server + airline].data[date].schedule.length);
-        let row = $('<tr></tr>').append(td1, td2);
-        tbody.append(row);
-    });
+    const k = 1024;
+    const sizes = ["Bytes", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
 
-    //Table head
-    let th1 = $('<th></th>').text('Date');
-    let th2 = $('<th></th>').text('# of Routes');
-    let headRow = $('<tr></tr>').append(th1, th2);
-    let thead = $('<thead></thead>').append(headRow);
-    //Table
-    let table = $('<table class="table table-hover"></table>').append(thead, tbody);
-    div.append(table);
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div class="container p-3">
-      <h5 class="text-nowrap">AirlineSim Enhancement Suite</h5>
+      <h5 class="text-nowrap">AirlineSim Enchancement Suite</h5>
 
       <p>Click here for options</p>
       <button type="button" id="aes-openOptions-btn" class="btn btn-light">Open Options</button>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div class="container p-3">
-      <h5 class="text-nowrap">AirlineSim Enchancement Suite</h5>
+      <h5 class="text-nowrap">AirlineSim Enhancement Suite</h5>
 
       <p>Click here for options</p>
       <button type="button" id="aes-openOptions-btn" class="btn btn-light">Open Options</button>


### PR DESCRIPTION
On the extension's options page, you can import and export your AES data (local storage), including to a different browser that supports AES.
Accessible from the extension's details page in Chrome. e.g. `chrome://extensions/?id=pfhocfphidmfpiplhgcpdekbidopnmeb` 

![newoptionsmenuitem](https://github.com/user-attachments/assets/ad488656-271b-4ba2-96f2-5fa0e323816f)

![image](https://github.com/user-attachments/assets/8681acc6-eac6-4b9a-a0fa-4681e64467dd)
